### PR TITLE
DRY up entry points, serialize workflow doc changes

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,59 +1,32 @@
 # Vuln Bank — Cursor Instructions
 
-Read this file first. Every session. No exceptions.
+Read this file, then .workflow/START HERE.md. Every session. No exceptions.
+
+## Model-Specific Settings
+
+- **You are:** Cursor
+- **Your operator:** (coworker)
+- **Your branch prefix:** `cursor/{##}-{task-slug}`
+- **Your label:** `cursor`
+- **Other model's label to watch:** `claude-code`
 
 ## Quick Start
 
-1. Read this file (you're doing it now)
+1. Read .workflow/START HERE.md for session rules, task workflow, and coordination protocol
 2. Read STATUS.md for current project state
-3. **Check GitHub Issues** for available work: `gh issue list --repo hrpatel/vuln-bank --label available`
-4. Check for any issues labeled "in-progress" + "claude-code" — avoid file conflicts with those
+3. Check GitHub Issues for available work: `gh issue list --repo hrpatel/vuln-bank --label available`
+4. Check for issues labeled "in-progress" + "claude-code" — avoid file conflicts with those
 5. Pick an available issue or ask your operator what to work on
-
-## Multi-Model Coordination
-
-This repo is worked on by two AI models in parallel:
-- Claude Code (CLI) — operated by one team member
-- Cursor — operated by another team member
-
-**Coordination happens through GitHub Issues**, not tasks/index.md. See .workflow/github-issues-coordination.md for the full guide, API reference, and examples.
-
-### The Rules
-
-1. Check before you start. Check GitHub Issues for "in-progress" tasks from the other model. If one touches the same files as yours, pick a different task.
-2. Claim your task. Assign yourself and label the issue "in-progress" + "cursor" in a single PATCH call.
-3. Branch per task. Always work on a feature branch, never directly on main.
-4. PRs are the merge point. Create PRs; humans merge.
-5. Unblock downstream. When you close an issue, check what it was blocking and flip newly-unblocked issues from "blocked" to "available".
-
-### Conflict Avoidance
-
-Each issue body lists the files it will edit. This is the conflict-detection mechanism:
-- If your task touches app.py and a Claude Code issue labeled "in-progress" also touches app.py, don't start yours yet.
-- If there's no file overlap, you're safe to work in parallel.
-- When in doubt, ask your operator.
 
 ## Workflow Reference
 
-Full workflow documentation is in .workflow/:
+All shared rules live in .workflow/ — that is the single source of truth:
 - START HERE.md — session rules and task workflow
 - How We Work.md — roles, coordination protocol, review process
-- github-issues-coordination.md — GitHub Issues coordination guide, API reference, and hard-problem solutions
+- github-issues-coordination.md — Issues coordination guide, API reference, and hard-problem solutions
 - Tips & Lessons.md — practical knowledge from AI-assisted development
 - task-template.md — standard format for archival task snapshots
 
 ## Project Context
 
 This is a deliberately vulnerable banking application for security testing practice. Work involves updating and extending the vulnerability bank — adding new vulnerability scenarios, improving existing ones, and maintaining the application.
-
-## Tracking
-
-- Log sessions to `metrics.md` using the structured field definitions (Phase, Driver, Operator, Work Category, Tool)
-- Log significant decisions to `decisions.md` using the structured entry format (Type, Category, Chosen path, Alternatives)
-- Both feed into the Meta Tracker dashboard (meta.jynaxxapps.com)
-
-## Code Changes
-
-- All changes go through PRs — no direct pushes to main
-- Humans merge — AI models never merge
-- Keep PRs focused: one concern per PR

--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -106,6 +106,12 @@ The creating model should review its own diff before flagging the PR as ready. C
 
 Every significant decision gets logged in `decisions.md`. This creates a record of how the project evolved, useful for both models and both operators.
 
+## Workflow Doc Changes
+
+Changes to `.cursorrules`, `CLAUDE.md`, or any file in `.workflow/` are **always single-model, serialized operations**. Never run two tasks that modify workflow docs in parallel. These files are read by both models at session start — concurrent edits create unpredictable behavior and guaranteed merge conflicts.
+
+If your task needs to update workflow docs and another model has an `in-progress` issue that also touches workflow docs, wait for theirs to merge first.
+
 ## Iteration Patterns
 
 1. **Small, targeted PRs** — one concern per PR

--- a/.workflow/START HERE.md
+++ b/.workflow/START HERE.md
@@ -26,12 +26,11 @@ A few minutes of research before implementing saves multiple iteration cycles af
 
 ## How to Start a Session
 
-1. Read this file (you're doing it now).
-2. Read `CLAUDE.md` (if you're Claude Code) or `.cursorrules` (if you're Cursor) for model-specific instructions.
-3. Check `STATUS.md` for current project state.
-4. **Check GitHub Issues** for available work: `gh issue list --repo hrpatel/vuln-bank --label available`. If there are available issues, pick one that doesn't conflict with any `in-progress` work.
-5. If no issues are available, ask your operator what to work on.
-6. For the full coordination guide, see `.workflow/github-issues-coordination.md`.
+1. Read your entry point (`CLAUDE.md` or `.cursorrules`) — it brought you here.
+2. Check `STATUS.md` for current project state.
+3. **Check GitHub Issues** for available work: `gh issue list --repo hrpatel/vuln-bank --label available`. If there are available issues, pick one that doesn't conflict with any `in-progress` work.
+4. If no issues are available, ask your operator what to work on.
+5. For the full coordination guide, see `.workflow/github-issues-coordination.md`.
 
 ## Task Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,32 @@
 # Vuln Bank — Claude Code Instructions
 
-**Read this file first. Every session. No exceptions.**
+**Read this file, then `.workflow/START HERE.md`. Every session. No exceptions.**
+
+## Model-Specific Settings
+
+- **You are:** Claude Code (CLI)
+- **Your operator:** Michael
+- **Your branch prefix:** `claude/{##}-{task-slug}`
+- **Your label:** `claude-code`
+- **Other model's label to watch:** `cursor`
 
 ## Quick Start
 
-1. Read this file (you're doing it now)
+1. Read `.workflow/START HERE.md` for session rules, task workflow, and coordination protocol
 2. Read `STATUS.md` for current project state
-3. **Check GitHub Issues** for available work: `gh issue list --repo hrpatel/vuln-bank --label available`
-4. Check for any issues labeled `in-progress` + `cursor` — avoid file conflicts with those
+3. Check GitHub Issues for available work: `gh issue list --repo hrpatel/vuln-bank --label available`
+4. Check for issues labeled `in-progress` + `cursor` — avoid file conflicts with those
 5. Pick an available issue or ask Michael what to work on
-
-## Multi-Model Coordination
-
-This repo is worked on by **two AI models in parallel**:
-- **Claude Code** (CLI) — operated by Michael
-- **Cursor** — operated by a coworker
-
-**Coordination happens through GitHub Issues**, not `tasks/index.md`. See `.workflow/github-issues-coordination.md` for the full guide, API reference, and examples.
-
-### The Rules
-
-1. **Check before you start.** Check GitHub Issues for `in-progress` tasks from the other model. If one touches the same files as yours, pick a different task.
-2. **Claim your task.** Assign yourself and label the issue `in-progress` + `claude-code` in a single PATCH call.
-3. **Branch per task.** Always work on a feature branch, never directly on main.
-4. **PRs are the merge point.** Create PRs; humans merge.
-5. **Unblock downstream.** When you close an issue, check what it was blocking and flip newly-unblocked issues from `blocked` to `available`.
-
-### Conflict Avoidance
-
-Each issue body lists the files it will edit. This is the conflict-detection mechanism:
-- If your task touches `app.py` and a Cursor issue labeled `in-progress` also touches `app.py`, **don't start yours yet**.
-- If there's no file overlap, you're safe to work in parallel.
-- When in doubt, ask Michael.
 
 ## Workflow Reference
 
-Full workflow documentation is in `.workflow/`:
+All shared rules live in `.workflow/` — that is the single source of truth:
 - `START HERE.md` — session rules and task workflow
 - `How We Work.md` — roles, coordination protocol, review process
-- `github-issues-coordination.md` — **GitHub Issues coordination guide, API reference, and hard-problem solutions**
+- `github-issues-coordination.md` — Issues coordination guide, API reference, and hard-problem solutions
 - `Tips & Lessons.md` — practical knowledge from AI-assisted development
 - `task-template.md` — standard format for archival task snapshots
 
 ## Project Context
 
 This is a deliberately vulnerable banking application for security testing practice. Work involves updating and extending the vulnerability bank — adding new vulnerability scenarios, improving existing ones, and maintaining the application.
-
-## Tracking
-
-- Log sessions to `metrics.md` using the structured field definitions (Phase, Driver, Operator, Work Category, Tool)
-- Log significant decisions to `decisions.md` using the structured entry format (Type, Category, Chosen path, Alternatives)
-- Both feed into the Meta Tracker dashboard (meta.jynaxxapps.com)
-
-## Code Changes
-
-- All changes go through PRs — no direct pushes to main
-- Michael or the coworker merges — AI models never merge
-- Keep PRs focused: one concern per PR


### PR DESCRIPTION
## Summary
- Slimmed `CLAUDE.md` and `.cursorrules` from ~60 lines to ~32 each — removed all duplicated rules (coordination, conflict avoidance, tracking, code changes). Each now contains only model-specific settings (name, operator, branch prefix, label) and points to `.workflow/` for everything shared.
- Added "Workflow Doc Changes" rule to `How We Work.md`: changes to entry points or `.workflow/` files are always single-model, serialized operations — no parallel edits.
- Fixed session start flow in `START HERE.md` to avoid circular "read your entry point" instructions.

Addresses Cursor workflow suggestions #5 (content duplication) and #8 (workflow docs as conflict surface).

## Test plan
- [ ] Verify `CLAUDE.md` still provides enough context for Claude Code to start a session
- [ ] Verify `.cursorrules` still provides enough context for Cursor to start a session
- [ ] Confirm all shared rules are accessible via `.workflow/START HERE.md` and `How We Work.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)