### PR TITLE
Add session close-out workflow with split metrics files (#55)

### DIFF
--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -106,6 +106,26 @@ The creating model should review its own diff before flagging the PR as ready. C
 
 Every significant decision gets logged in `decisions.md`. This creates a record of how the project evolved, useful for both models and both operators.
 
+## Metrics & Session Tracking
+
+### Split Metrics Files
+
+To avoid merge conflicts on shared metrics, each model writes to its own file:
+
+| File | Owner | Purpose |
+|------|-------|---------|
+| `metrics-claude.md` | Claude Code | Claude Code's session logs |
+| `metrics-cursor.md` | Cursor | Cursor's session logs |
+| `metrics.md` | Claude Code (merger) | Merged master — do not edit directly |
+
+Both per-model files use identical fields that match the Meta Tracker data model. This ensures reliable sync to the dashboard.
+
+### Who Merges
+
+**Claude Code is always the merger.** It combines both model files into `metrics.md` and pushes to Meta Tracker. This happens opportunistically — at session start if there's unsynced Cursor data, or at session close-out.
+
+Neither model should edit `metrics.md` directly. If you need to correct a past entry, edit it in your own metrics file and let the merge process update the master.
+
 ## Workflow Doc Changes
 
 Changes to `.cursorrules`, `CLAUDE.md`, or any file in `.workflow/` are **always single-model, serialized operations**. Never run two tasks that modify workflow docs in parallel. These files are read by both models at session start — concurrent edits create unpredictable behavior and guaranteed merge conflicts.

--- a/.workflow/START HERE.md
+++ b/.workflow/START HERE.md
@@ -66,6 +66,33 @@ GitHub Issues support native dependency tracking:
 6. **Decisions updated** — if a significant decision was made, update `decisions.md`.
 7. **STATUS.md updated** — reflect the current project state.
 
+## Session Close-Out
+
+When your operator says "close this session" (or equivalent), follow these steps:
+
+1. **Finish or pause current work** — commit, push, and create/update PRs for any in-progress tasks.
+2. **Update your metrics file** — add a session row to your model's file:
+   - Claude Code → `metrics-claude.md`
+   - Cursor → `metrics-cursor.md`
+   - Include: session number, date, duration, PRs, decisions, focus area, phase, driver, operator, work category, bugs fixed.
+   - Add code volume and PR activity rows as applicable.
+3. **Update `decisions.md`** — if any significant decisions were made this session.
+4. **Update `STATUS.md`** — reflect the current project state.
+5. **Release claimed issues** — any `in-progress` issues you didn't finish should be relabeled `available` so the other model can pick them up.
+6. **Commit and PR** — push your metrics/docs update as part of your final PR, or as a separate close-out PR.
+
+> **Do not edit `metrics.md` directly.** Each model writes to its own file. Claude Code is the merger — it combines both files into `metrics.md` (master) and syncs to Meta Tracker.
+
+### Metrics Merge (Claude Code only)
+
+At session start or close-out, Claude Code checks for unsynced data:
+1. Pull latest `metrics-cursor.md` — if Cursor added sessions since last merge, incorporate them.
+2. Pull latest `metrics-claude.md` — include own session data.
+3. Merge both into `metrics.md` (the master file).
+4. Push updated data to Meta Tracker (`vulnBankMetrics.ts` + `vulnBankProject.ts`).
+
+This can happen at any natural breakpoint — no need to wait for the other model.
+
 ## Review Cadence
 
 **After every 2-3 merges**, do a quick review pass:

--- a/metrics-claude.md
+++ b/metrics-claude.md
@@ -1,0 +1,45 @@
+# Vuln Bank — Claude Code Session Metrics
+
+**Owner:** Claude Code
+**Purpose:** Per-session metrics log. Claude Code updates this file at session close-out. Claude Code merges this + `metrics-cursor.md` into `metrics.md` (master) and syncs to Meta Tracker.
+
+---
+
+## Sessions
+
+| Session | Date | Duration (approx) | PRs | Decisions | Focus Area | Phase | Driver | Operator | Work Category | Tool | Bugs Fixed |
+|---------|------|--------------------|-----|-----------|------------|-------|--------|----------|---------------|------|------------|
+
+## Code Volume
+
+| Session | Date | Lines Added | Lines Deleted | Net Change | Key Files Changed |
+|---------|------|-------------|---------------|------------|-------------------|
+
+## PR Activity
+
+| Session | Date | PRs Created | PRs Merged | Commits | Notes |
+|---------|------|-------------|------------|---------|-------|
+
+## Bugs Found/Fixed
+
+| # | Date Found | Summary | Severity | Source | Resolution | Session Fixed |
+|---|-----------|---------|----------|--------|------------|---------------|
+
+---
+
+### Field Reference
+
+These fields must match the Meta Tracker data model for reliable sync.
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| **Phase** | Research · Spec · Build · Review · Shipped | Project lifecycle phase |
+| **Driver** | human · ai · collaborative | Who steered the work |
+| **Operator** | michael · hrpatel · joint | Which human operator |
+| **Work Category** | Feature · Refactor · Bug · Tooling · Scripting · Data · Local-Tooling · Planning | Type of work |
+| **Tool** | Claude Code | Always "Claude Code" in this file |
+| **Bugs Fixed** | Count or issue numbers | Issues closed as bugs in this session |
+
+---
+
+*Updated at each session close-out. Do not edit `metrics.md` directly — Claude Code merges both model files into the master.*

--- a/metrics-cursor.md
+++ b/metrics-cursor.md
@@ -1,0 +1,45 @@
+# Vuln Bank — Cursor Session Metrics
+
+**Owner:** Cursor
+**Purpose:** Per-session metrics log. Cursor updates this file at session close-out. Claude Code merges this + `metrics-claude.md` into `metrics.md` (master) and syncs to Meta Tracker.
+
+---
+
+## Sessions
+
+| Session | Date | Duration (approx) | PRs | Decisions | Focus Area | Phase | Driver | Operator | Work Category | Tool | Bugs Fixed |
+|---------|------|--------------------|-----|-----------|------------|-------|--------|----------|---------------|------|------------|
+
+## Code Volume
+
+| Session | Date | Lines Added | Lines Deleted | Net Change | Key Files Changed |
+|---------|------|-------------|---------------|------------|-------------------|
+
+## PR Activity
+
+| Session | Date | PRs Created | PRs Merged | Commits | Notes |
+|---------|------|-------------|------------|---------|-------|
+
+## Bugs Found/Fixed
+
+| # | Date Found | Summary | Severity | Source | Resolution | Session Fixed |
+|---|-----------|---------|----------|--------|------------|---------------|
+
+---
+
+### Field Reference
+
+These fields must match the Meta Tracker data model for reliable sync.
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| **Phase** | Research · Spec · Build · Review · Shipped | Project lifecycle phase |
+| **Driver** | human · ai · collaborative | Who steered the work |
+| **Operator** | michael · hrpatel · joint | Which human operator |
+| **Work Category** | Feature · Refactor · Bug · Tooling · Scripting · Data · Local-Tooling · Planning | Type of work |
+| **Tool** | Cursor | Always "Cursor" in this file |
+| **Bugs Fixed** | Count or issue numbers | Issues closed as bugs in this session |
+
+---
+
+*Updated at each session close-out. Do not edit `metrics.md` directly — Claude Code merges both model files into the master.*

--- a/metrics.md
+++ b/metrics.md
@@ -9,6 +9,9 @@
 | **Tracking Since** | March 6, 2026 |
 | **Last Updated** | March 10, 2026 (Session 7) |
 
+
+> **This is the merged master.** Do not edit directly. Each model writes to `metrics-claude.md` or `metrics-cursor.md`. Claude Code merges both into this file and syncs to Meta Tracker.
+
 ---
 
 ## 1. Code Volume


### PR DESCRIPTION
## Summary
- Created `metrics-claude.md` and `metrics-cursor.md` — each model writes to its own file at session close-out
- `metrics.md` is now the merged master — Claude Code maintains it, neither model edits directly
- Added Session Close-Out checklist to `.workflow/START HERE.md` (both models see it)
- Added Metrics & Session Tracking section to `.workflow/How We Work.md`
- Fields match Meta Tracker data model for reliable sync

## How it works
1. Operator says "close this session"
2. Model updates its own metrics file (sessions, code volume, PRs, bugs)
3. Claude Code merges both files into `metrics.md` and syncs to Meta Tracker
4. No merge conflicts — each model owns its own file

## Files changed
- `metrics-claude.md` (new) — Claude Code session log
- `metrics-cursor.md` (new) — Cursor session log
- `metrics.md` — added merger note
- `.workflow/START HERE.md` — added Session Close-Out + Metrics Merge sections
- `.workflow/How We Work.md` — added Metrics & Session Tracking section

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)