### PR TITLE
Session 8 close-out: metrics + status update

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 **Last updated:** March 10, 2026
 **Repo:** https://github.com/hrpatel/vuln-bank
 **Live site:** N/A (runs locally via Docker)
-**Current phase:** Spec
+**Current phase:** Build
 **Current state:** Workflow cleanup complete. Obsolete workflow artifacts moved to `.archive/`; live docs updated to reference GitHub Issues and `.archive` paths.
 
 ---
@@ -26,6 +26,7 @@ A deliberately vulnerable banking application designed for practicing security t
 ## Recent Work
 
 - **Cursor session (Mar 10):** Created `.archive/` and moved obsolete workflow artifacts — `tasks/`, `workflow-suggestions-cursor.md`, `REVIEW-REQUEST.md`. Added `.archive/README.md` and `.archive/tasks/done/`. Updated `.workflow/` docs and `STATUS.md` to use `.archive` paths and GitHub Issues as coordination layer.
+- **Session 8 (Mar 10):** Fixed 4 bugs (#21, #22, #26, #36) in PR #53. Added session close-out workflow with split metrics files (PR #56). Meta Tracker synced with all sessions including Cursor's.
 - **Session 34:** GitHub Issues POC validated — sub-issues, dependencies, labels, claiming, signaling all work. Coordination guide written (`.workflow/github-issues-coordination.md`). All workflow docs updated to reference Issues instead of task index. (PR #11)
 - **Session 33:** Designed GitHub Issues coordination system to replace file-based task index (decisions.md updated)
 - Cursor reviewed workflow and identified 9 improvement areas (see `.archive/workflow-suggestions-cursor.md`)
@@ -42,7 +43,8 @@ A deliberately vulnerable banking application designed for practicing security t
 - **Two AI models working in parallel:**
   - Claude Code (CLI) — operated by Michael
   - Cursor — operated by coworker
-- Coordination via GitHub Issues (replacing file-based task index — see `.workflow/github-issues-coordination.md`)
+- Coordination via GitHub Issues (see `.workflow/github-issues-coordination.md`)
+- Metrics: split files per model (`metrics-claude.md`, `metrics-cursor.md`), Claude Code merges into `metrics.md`
 
 ---
 

--- a/metrics-claude.md
+++ b/metrics-claude.md
@@ -9,21 +9,29 @@
 
 | Session | Date | Duration (approx) | PRs | Decisions | Focus Area | Phase | Driver | Operator | Work Category | Tool | Bugs Fixed |
 |---------|------|--------------------|-----|-----------|------------|-------|--------|----------|---------------|------|------------|
+| 8 | Mar 10 | -- | 3 | 1 | Fixed 4 bugs (#21, #22, #26, #36), Meta Tracker sync, session close-out workflow (#55) | Build | collaborative | michael | Bug | Claude Code | #21, #22, #26, #36 |
 
 ## Code Volume
 
 | Session | Date | Lines Added | Lines Deleted | Net Change | Key Files Changed |
 |---------|------|-------------|---------------|------------|-------------------|
+| 8 | Mar 10 | 159 | 41 | +118 | README.md, app.py, auth.py, Dockerfile, openapi.json, index.html, metrics-claude.md, metrics-cursor.md, START HERE.md, How We Work.md, metrics.md |
 
 ## PR Activity
 
 | Session | Date | PRs Created | PRs Merged | Commits | Notes |
 |---------|------|-------------|------------|---------|-------|
+| 8 | Mar 10 | 1 | -- | 2 | PR #53: Fix 4 bugs (Commando-X refs, debug prints, dead SQLite, upload perms) |
+| 8 | Mar 10 | 1 | 1 | 1 | PR #56: Session close-out workflow + split metrics files (#55) |
 
 ## Bugs Found/Fixed
 
 | # | Date Found | Summary | Severity | Source | Resolution | Session Fixed |
 |---|-----------|---------|----------|--------|------------|---------------|
+| #21 | Mar 10 | Commando-X repo references throughout codebase | Medium | Codebase audit | Fixed (PR #53) | 8 |
+| #22 | Mar 10 | Dead SQLite code in auth.py — 3 endpoints crash at runtime | High | Codebase audit | Fixed (PR #53) | 8 |
+| #26 | Mar 10 | Overly permissive uploads directory (chmod 777) | Low | Codebase audit | Fixed (PR #53) | 8 |
+| #36 | Mar 10 | Debug prints exposing usernames, SQL queries, JWT tokens | Medium | Codebase audit | Fixed (PR #53) | 8 |
 
 ---
 


### PR DESCRIPTION
## Summary
First use of the new session close-out process (issue #55).

- `metrics-claude.md` — Session 8 data: 4 bugs fixed (#21, #22, #26, #36), 3 PRs, 1 decision
- `STATUS.md` — Updated to Build phase, recent work logged

## Session 8 Summary
- Fixed 4 bugs in PR #53 (Commando-X refs, debug prints, dead SQLite, upload perms)
- Created session close-out workflow with split metrics files (PR #56)
- Synced all metrics to Meta Tracker (including Cursor sessions 5 and 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)