### PR TITLE
Add completed label to issue lifecycle docs

### DIFF
--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -36,6 +36,7 @@ Both models:
 | `blocked` | Has unresolved dependencies |
 | `claude-code` | Owned by Claude Code |
 | `cursor` | Owned by Cursor |
+| `completed` | Work finished and merged |
 
 > **Historical note:** `tasks/index.md` was the original coordination mechanism but had a visibility gap — both models edited it on branches, so neither could see the other's claims. Issues solve this by being branch-independent.
 

--- a/.workflow/github-issues-coordination.md
+++ b/.workflow/github-issues-coordination.md
@@ -29,6 +29,7 @@ When an issue closes, a snapshot can be saved to `.archive/tasks/done/` for offl
 | `cursor` | Blue | Owned by Cursor |
 | `created-by:claude-code` | Purple | Issue was created by Claude Code |
 | `created-by:cursor` | Blue | Issue was created by Cursor |
+| `completed` | Green | Work finished and merged |
 
 ---
 
@@ -69,9 +70,16 @@ gh api repos/hrpatel/vuln-bank/issues/{N}/comments -X POST \
   -f body="**[Claude Code]** PR #__ ready for review/merge. Issue will close when PR is merged."
 ```
 
-When the **PR is merged**, the person merging should:
+When the **PR is merged**, the person merging (or the model at session close-out) should:
 - Rely on automation to close the issue if the PR body contains `Fixes #N`, or close the issue manually.
+- **Swap labels:** replace `in-progress` with `completed` so closed issues don't appear to still be in progress.
 - Check what the closed issue was blocking and flip any newly-unblocked issues from `blocked` to `available` (see dependency commands below).
+
+```bash
+# After merge: swap in-progress → completed
+gh api repos/hrpatel/vuln-bank/issues/{N}/labels/in-progress -X DELETE
+gh api repos/hrpatel/vuln-bank/issues/{N}/labels -X POST -f "labels[]=completed"
+```
 
 ```bash
 # After merge: what did issue N block?


### PR DESCRIPTION
Adds completed label to coordination guide and How We Work label tables. Documents the in-progress → completed label swap when PRs merge.