### PR TITLE
Fix bare exception handlers and stale index references (#37, #15)

### DIFF
--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -19,7 +19,7 @@ Both operators:
 Both models:
 - Read the workflow docs at session start
 - Check for conflicts before starting work
-- Claim tasks in the index before working on them
+- Claim tasks via GitHub Issues before working on them
 - Create PRs for all code changes
 - Never merge, never push directly to main
 
@@ -59,7 +59,7 @@ Example: `claude/03-add-xss-scenario`, `cursor/04-update-auth-tests`
 ### Handling Conflicts
 
 If both models accidentally start tasks that touch the same files:
-1. The model that started **second** (later timestamp in the index) yields
+1. The model that started **second** (later claiming timestamp on the issue) yields
 2. That model stashes or shelves its work
 3. Wait for the first model's PR to merge
 4. Rebase and continue

--- a/app.py
+++ b/app.py
@@ -144,8 +144,8 @@ def ai_rate_limit(f):
                     
                     # Both checks passed, proceed with authenticated function
                     return f(*args, **kwargs)
-            except:
-                pass  # Fall through to unauthenticated handling
+            except Exception:
+                pass  # Token verification failed — fall through to unauthenticated handling
         
         # Unauthenticated mode: rate limit by IP only
         ip_key = f"ai_unauth_ip_{client_ip}"
@@ -2037,8 +2037,8 @@ def ai_rate_limit_status():
                         'user_id': user_data['user_id'],
                         'username': user_data['username']
                     }
-            except:
-                pass  # Token invalid, stay with unauthenticated status
+            except Exception:
+                pass  # Token invalid — stay with unauthenticated status
         
         return jsonify(status)
         


### PR DESCRIPTION
## Summary
- Replace bare `except:` with `except Exception:` in `app.py` (lines 147, 2040) so `KeyboardInterrupt` and `SystemExit` aren't silently swallowed
- Update two stale "index" references in `How We Work.md` to say "GitHub Issues"

Fixes #37
Fixes #15

## Files Changed
- `app.py` — 2 bare exception handlers → typed
- `.workflow/How We Work.md` — 2 stale text references → updated

## Test Plan
- [ ] App starts without errors
- [ ] AI rate limiting still falls through to unauthenticated mode on bad tokens
- [ ] How We Work.md reads correctly with no stale index mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)