### PR TITLE
Modernize Docker setup: Python 3.12, Compose V2, health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
-# Install PostgreSQL client
+# Install PostgreSQL client and curl (for health check)
 RUN apt-get update && apt-get install -y \
     postgresql-client \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -19,5 +20,8 @@ COPY . .
 RUN chmod 755 static/uploads
 
 EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:5000/ || exit 1
 
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cd vuln-bank
 
 2. Start the application:
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 The application will be available at `http://localhost:5000`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,25 @@
-version: '3.8'
-
 services:
   web:
     build: .
     ports:
       - "5000:5000"
       - "80:5000"
-      # - "443:5000" 
-
     environment:
       - DB_NAME=vulnerable_bank
       - DB_USER=postgres
       - DB_PASSWORD=postgres
-      - DB_HOST=db 
+      - DB_HOST=db
       - DB_PORT=5432
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - ./static/uploads:/app/static/uploads
     networks:
       - vuln_network
 
   db:
-    image: postgres:13
+    image: postgres:16
     environment:
       - POSTGRES_DB=vulnerable_bank
       - POSTGRES_USER=postgres
@@ -31,6 +28,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - vuln_network
 


### PR DESCRIPTION
## Summary
- Upgrade Python base image from 3.9 (EOL) to 3.12
- Upgrade Postgres from 13 to 16
- Remove deprecated version field (Compose V2)
- Add health checks to both web (curl) and db (pg_isready) services
- Web service waits for healthy db before starting
- Update README commands to docker compose (V2 CLI)

Fixes #23
Fixes #25
Fixes #39

## Files Changed
- Dockerfile — Python 3.12, curl install, HEALTHCHECK directive
- docker-compose.yml — V2 syntax, Postgres 16, health checks, depends_on condition
- README.md — docker-compose → docker compose

## Test Plan
- [ ] docker compose build succeeds
- [ ] docker compose up starts both services
- [ ] docker ps shows health status for both containers
- [ ] App accessible at localhost:5000