### PR TITLE
Add workflow onboarding doc (macOS & WSL)

### DIFF
--- a/.workflow/START HERE.md
+++ b/.workflow/START HERE.md
@@ -104,6 +104,7 @@ This can happen at any natural breakpoint — no need to wait for the other mode
 | **Tips & Lessons** | `.workflow/` | When you hit a technical snag |
 | **decisions.md** | Repo root | When you need project history; log decisions using the structured format |
 | **metrics.md** | Repo root | When updating tracking data; log sessions using the field definitions |
+| **Onboarding** | `.workflow/onboarding.md` | First-time local setup (git, gh, optional bd/acli) — macOS & WSL |
 | **Issue tracker** | `.workflow/issue-tracker.md` | Which tracker this project uses; read first, then follow its coordination guide |
 | **Bootstrap** | `.workflow/bootstrap.md` | One-time setup when choosing or changing the issue tracker |
 | **GitHub Coordination** | `.workflow/github-issues-coordination.md` | If tracker is GitHub Issues |

--- a/.workflow/bootstrap.md
+++ b/.workflow/bootstrap.md
@@ -2,6 +2,8 @@
 
 Use this checklist **once** when setting up multi-model AI collaboration on a new repo (or when changing how the project tracks work). After this, agents and operators follow the workflow in START HERE and the coordination guide chosen below.
 
+**New to this repo?** Complete [onboarding.md](onboarding.md) first (git, GitHub CLI, and any tracker-specific tools for macOS or WSL). Then return here for project-level setup.
+
 ---
 
 ## 1. Choose the issue tracker

--- a/.workflow/onboarding.md
+++ b/.workflow/onboarding.md
@@ -1,0 +1,95 @@
+# Workflow Onboarding — Local Environment Setup
+
+This doc gets your machine ready to **participate in the workflow**: clone the repo, use the issue tracker, and open/update PRs. It does not cover running the vuln-bank app locally (see the repo **README** for that).
+
+Supported environments: **macOS** and **WSL** (Windows Subsystem for Linux, Ubuntu/Debian).
+
+---
+
+## Required (everyone)
+
+### Git
+
+- **macOS:** Usually pre-installed. If not: `xcode-select --install` or `brew install git`.
+- **WSL:**  
+  `sudo apt update && sudo apt install -y git`
+
+**Verify:** `git --version`
+
+### GitHub CLI (`gh`)
+
+Used for PRs and (when the project uses GitHub Issues) for the issue tracker. Authenticate so you can push and create PRs.
+
+- **macOS:**  
+  `brew install gh`  
+  Then: `gh auth login` (choose GitHub.com, HTTPS or SSH, authenticate in browser).
+
+- **WSL:** Add GitHub’s APT repo and install:
+  ```bash
+  (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
+    && sudo mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update && sudo apt install gh -y
+  ```
+  Then: `gh auth login` (same as macOS).
+
+**Verify:** `gh auth status`
+
+---
+
+## Optional (by issue tracker)
+
+Read [.workflow/issue-tracker.md](issue-tracker.md) to see which tracker this project uses. Install only the tools for that tracker.
+
+### If the project uses Beads
+
+You need **Beads (`bd`)** and **Dolt** (Beads’ storage backend).
+
+- **macOS:**  
+  `brew install beads dolt`  
+  Or install script (installs both):  
+  `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`
+
+- **WSL:**  
+  `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`  
+  (Script detects Linux and installs; ensure Dolt is installed if the script doesn’t pull it — see [Beads installation docs](https://steveyegge.github.io/beads/getting-started/installation).)
+
+**Verify:** `bd --version`. Then in the repo: `bd init` or `bd init --stealth` (see [beads-coordination.md](beads-coordination.md)).
+
+### If the project uses Jira
+
+You need **Atlassian CLI (`acli`)**.
+
+- **macOS:**  
+  `brew tap atlassian/homebrew-acli && brew install acli`  
+  Then: `acli auth`
+
+- **WSL:** Debian/Ubuntu:
+  ```bash
+  sudo apt-get install -y wget gnupg2
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  wget -nv -O- https://acli.atlassian.com/gpg/public-key.asc | sudo gpg --dearmor -o /etc/apt/keyrings/acli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/acli-archive-keyring.gpg] https://acli.atlassian.com/linux/deb stable main" | sudo tee /etc/apt/sources.list.d/acli.list > /dev/null
+  sudo apt update && sudo apt install -y acli
+  ```
+  Then: `acli auth`
+
+**Verify:** `acli --version` and `acli auth` (log in to your Atlassian Cloud site). See [jira-coordination.md](jira-coordination.md).
+
+---
+
+## Checklist
+
+1. **Clone the repo** (if you haven’t): `git clone <repo-url>` and `cd` into it.
+2. **Install required tools:** Git and GitHub CLI (see above). Run `gh auth login` if needed.
+3. **Check the issue tracker:** Read [.workflow/issue-tracker.md](issue-tracker.md). If the project uses Beads or Jira, install and verify those tools.
+4. **Confirm:** `git --version`, `gh auth status`, and (if applicable) `bd --version` or `acli --version`.
+
+After this, follow [.workflow/START HERE.md](START%20HERE.md) and the coordination guide linked in issue-tracker.md. For one-time project setup (e.g. choosing the tracker), see [.workflow/bootstrap.md](bootstrap.md).
+
+---
+
+*Last updated: March 2026*


### PR DESCRIPTION
- .workflow/onboarding.md: required (git, gh), optional by tracker (bd+Dolt, acli)
- START HERE: add Onboarding to Key References
- bootstrap: link to onboarding for new contributors

Made-with: Cursor