### PR TITLE
docs: feature-branch-only workflow — never push to main

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,6 +17,8 @@ Read this file, then .workflow/START HERE.md. Every session. No exceptions.
 3. Read .workflow/issue-tracker.md to see which issue tracker this project uses, then follow the coordination guide linked there to find and claim work (and to avoid file conflicts with the other model's in-progress work)
 4. If no work is available, ask your operator what to work on
 
+Work on a feature branch only; never push to main.
+
 ## Workflow Reference
 
 All shared rules live in .workflow/ — that is the single source of truth:

--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -21,7 +21,7 @@ Both models:
 - Check for conflicts before starting work
 - Claim tasks via the issue tracker set in `.workflow/issue-tracker.md` before working on them
 - Create PRs for all code changes
-- Never merge, never push directly to main
+- Work only on a feature branch; push only that branch. Never merge, never push directly to main
 
 ## Coordination Protocol
 
@@ -36,6 +36,7 @@ One-time setup (e.g. when creating or changing the choice) is in `.workflow/boot
 1. Read `.workflow/issue-tracker.md` to see which tracker this project uses.
 2. Open the coordination guide linked there.
 3. Use that guide to find available work, check for in-progress work from the other model (and its "Files to edit"), and claim a task without file overlap.
+4. Create or switch to a feature branch (see Branch Naming) before making changes.
 
 ### Branch Naming
 

--- a/.workflow/START HERE.md
+++ b/.workflow/START HERE.md
@@ -27,9 +27,10 @@ A few minutes of research before implementing saves multiple iteration cycles af
 ## How to Start a Session
 
 1. Read your entry point — `CLAUDE.md` for CLI agents (e.g. Claude Code), `.cursorrules` for Cursor — it brought you here.
-2. Check `STATUS.md` for current project state.
-3. **Read `.workflow/issue-tracker.md`** to see which issue tracker this project uses. Follow the **coordination guide linked there** to find available work and claim a task (and to check for in-progress work from the other model).
-4. If no work is available, ask your operator what to do next.
+2. Create or checkout a feature branch (e.g. `cursor/XX-slug` or `claude/XX-slug` per `.workflow/How We Work.md`). Do not commit or push to `main`.
+3. Check `STATUS.md` for current project state.
+4. **Read `.workflow/issue-tracker.md`** to see which issue tracker this project uses. Follow the **coordination guide linked there** to find available work and claim a task (and to check for in-progress work from the other model).
+5. If no work is available, ask your operator what to do next.
 
 ## Task Workflow
 
@@ -51,7 +52,7 @@ Follow the coordination guide linked in `.workflow/issue-tracker.md` to create t
 
 ## Task Completion Checklist
 
-1. **Rebase on main before closing** — when closing a session: fetch and rebase (`git fetch origin main && git rebase origin/main`), resolve any conflicts, then commit and push; use `git push --force-with-lease origin <branch>` if the branch was already pushed. Verify the PR shows no conflicts.
+1. **Rebase on main before closing** — when closing a session: fetch and rebase (`git fetch origin main && git rebase origin/main`), resolve any conflicts, then commit and push. Push only to your feature branch (e.g. `git push --force-with-lease origin <your-branch>`); never push to `main`. Verify the PR shows no conflicts.
 2. **Before every push** — update your model's metrics file (`.metrics/metrics-claude.md` or `.metrics/metrics-cursor.md`) and include it in the commit you're pushing, so each push carries up-to-date metrics. If there's no new work this session, no metrics change is required.
 3. **PR created or updated** — open or update the PR. Follow the coordination guide (`.workflow/issue-tracker.md`) for when to close or complete the tracker issue (e.g. when the PR is merged).
 4. **Downstream unblocked** — when the PR is merged, follow the coordination guide to flip any newly-unblocked work to available (or document in the PR comment).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Set these for your agent (example values shown for Claude Code):
 3. Read `.workflow/issue-tracker.md` to see which issue tracker this project uses, then follow the coordination guide linked there to find and claim work (and to avoid file conflicts with the other model’s in-progress work)
 4. If no work is available, ask your operator what to work on
 
+Work on a feature branch only; never push to main.
+
 ## Workflow Reference
 
 All shared rules live in `.workflow/` — that is the single source of truth:

--- a/docs/specs/2026-03-13-feature-branch-only-workflow.md
+++ b/docs/specs/2026-03-13-feature-branch-only-workflow.md
@@ -1,0 +1,26 @@
+# Feature-Branch-Only Workflow — Design Note
+
+**Date:** 2026-03-13  
+**Summary:** All changes are made on feature branches; agents and humans never push to `main`. This note records where the rule is stated so it is visible at session start and at push time.
+
+## Rule
+
+- Work only on a feature branch (create or checkout before making changes).
+- Push only that branch (e.g. `git push --force-with-lease origin <branch>`).
+- Never push to `main`. Humans merge PRs; agents do not merge.
+
+## Where It Is Stated
+
+| Location | Purpose |
+|----------|--------|
+| **START HERE.md** | "How to Start a Session": create/checkout feature branch; do not commit/push to main. Task Completion Checklist: push only to your feature branch; never to main. |
+| **How We Work.md** | "Both models": work only on a feature branch; push only that branch; never push to main. Optionally "Before Starting a Task": create or switch to feature branch. |
+| **.cursorrules** / **CLAUDE.md** | One line in Quick Start / Workflow Reference: work on a feature branch only; never push to main. |
+
+## Branch Naming
+
+Per How We Work: `claude/{##}-{task-slug}`, `cursor/{##}-{task-slug}`.
+
+---
+
+*Design approved 2026-03-13. Changes applied in same session.*


### PR DESCRIPTION
- Design note: docs/specs/2026-03-13-feature-branch-only-workflow.md
- START HERE: create/checkout feature branch at session start; push only to branch in checklist
- How We Work: work only on feature branch, push only that branch; add step before making changes
- .cursorrules, CLAUDE.md: one-line rule in Quick Start

Made-with: Cursor