### PR TITLE
docs(workflow): mandatory Beads claim before branch or file edits

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,6 +17,8 @@ Read this file, then .workflow/START HERE.md. Every session. No exceptions.
 3. Read .workflow/issue-tracker.md to see which issue tracker this project uses, then follow the coordination guide linked there to find and claim work (and to avoid file conflicts with the other model's in-progress work)
 4. If no work is available, ask your operator what to work on
 
+**Beads — claim first:** Run `bd update <id> --claim` and succeed *before* creating a branch or editing files for that task. If claim fails, pick another task.
+
 Work on a feature branch only; never push to main.
 
 ## Workflow Reference

--- a/.workflow/How We Work.md
+++ b/.workflow/How We Work.md
@@ -35,8 +35,8 @@ One-time setup (e.g. when creating or changing the choice) is in `.workflow/boot
 
 1. Read `.workflow/issue-tracker.md` to see which tracker this project uses.
 2. Open the coordination guide linked there.
-3. Use that guide to find available work, check for in-progress work from the other model (and its "Files to edit"), and claim a task without file overlap.
-4. Create or switch to a feature branch (see Branch Naming) before making changes.
+3. Use that guide to find available work and check for in-progress work from the other model (and its "Files to edit"). **Beads:** `bd update <id> --claim` must **succeed** before any branch or file edits for that task.
+4. Create or switch to a feature branch (see Branch Naming) only **after** a successful claim.
 
 ### Branch Naming
 
@@ -61,8 +61,8 @@ If a merge conflict arises in a PR, the model that created the PR resolves it.
 1. Operator describes what they want
 2. AI model asks clarifying questions if needed
 3. AI model checks the issue tracker (see `.workflow/issue-tracker.md`) for conflicts
-4. AI model creates a task (if one doesn't exist) and claims it per the coordination guide
-5. AI model works on a feature branch
+4. AI model creates a task (if one doesn't exist) and **successfully** claims it per the coordination guide (Beads: `bd update <id> --claim` before any branch or edits)
+5. AI model works on a feature branch (only after claim succeeds)
 6. AI model creates a PR
 7. **Human merges** the PR
 8. When the PR is merged, the tracker issue is closed or completed per the coordination guide. The person who merges unblocks downstream work and updates STATUS.md / tracking docs as needed.

--- a/.workflow/START HERE.md
+++ b/.workflow/START HERE.md
@@ -11,7 +11,7 @@
 3. **Tasks are sequential unless marked parallel-safe.** Parallel tasks touching the same files can revert each other.
 4. **Ask before acting on anything destructive or ambiguous.** When in doubt, ask.
 5. **Check for conflicts before starting.** Use the coordination guide (see `.workflow/issue-tracker.md`) to see in-progress work and verify no task from the other model touches your files.
-6. **Claim your work.** Claim a task in the project’s issue tracker when you start (via the coordination guide). Create a PR when you finish; the tracker issue is closed or completed per the guide (e.g. when the PR is merged).
+6. **Claim before you touch the task.** For **Beads**, you must run `bd update <id> --claim` and have it **succeed** before you create a feature branch or edit any file for that task. If claim fails (already claimed), pick another task from `bd ready --unassigned`. Same discipline for other trackers: claim must precede implementation. Create a PR when you finish; close the tracker item per the coordination guide.
 
 ## Before You Build
 
@@ -27,10 +27,10 @@ A few minutes of research before implementing saves multiple iteration cycles af
 ## How to Start a Session
 
 1. Read your entry point — `CLAUDE.md` for CLI agents (e.g. Claude Code), `.cursorrules` for Cursor — it brought you here.
-2. Create or checkout a feature branch (e.g. `cursor/XX-slug` or `claude/XX-slug` per `.workflow/How We Work.md`). Do not commit or push to `main`.
-3. Check `STATUS.md` for current project state.
-4. **Read `.workflow/issue-tracker.md`** to see which issue tracker this project uses. Follow the **coordination guide linked there** to find available work and claim a task (and to check for in-progress work from the other model).
-5. If no work is available, ask your operator what to do next.
+2. Check `STATUS.md` for current project state.
+3. **Read `.workflow/issue-tracker.md`** and the **coordination guide** it links to. **Beads:** run `bd ready --unassigned`, choose one task, run `bd update <id> --claim`. **Do not proceed until claim succeeds.** If it fails, choose a different task. Only after a successful claim may you create a branch or edit files for that work item.
+4. Create or checkout a feature branch (e.g. `cursor/XX-slug` per `.workflow/How We Work.md`). Do not commit or push to `main`.
+5. If no unclaimed work is available, ask your operator what to do next.
 
 ## Task Workflow
 

--- a/.workflow/Tips & Lessons.md
+++ b/.workflow/Tips & Lessons.md
@@ -18,7 +18,7 @@ A living document capturing what we've learned — from both AI models and both 
 - **GitHub Issues are the coordination layer.** Before starting any work, check `gh issue list --repo hrpatel/vuln-bank` for in-progress work. If another model has an issue that touches the same files, pick something else.
 - **Branch naming signals ownership.** Use `claude/` or `cursor/` prefixes so it's obvious who's working where.
 - **File-level granularity is enough.** You don't need line-level locking — if two tasks touch the same file, they conflict. Keep tasks scoped to avoid this.
-- **Claim your issue before you start coding.** The gap between deciding to work on something and claiming the issue is where collisions happen.
+- **Claim before branch or edits (Beads: `bd update <id> --claim`).** The gap between picking a task and claiming it is where two agents duplicate work. Claim must succeed first; if it fails, pick another task—do not implement anyway.
 
 ## AI Code Generation
 

--- a/.workflow/beads-coordination.md
+++ b/.workflow/beads-coordination.md
@@ -61,11 +61,16 @@ Use 'bd' for task tracking. See .workflow/beads-coordination.md.
 
 ## Workflow
 
+### Claim before branch or edits (mandatory)
+
+**Order for every implementation session:** (1) `bd ready --unassigned` (or equivalent) → (2) pick **one** task ID → (3) `bd update <id> --claim` → (4) **only if claim succeeds**, create your git feature branch and edit files.
+
+If claim fails, another agent holds that task—pick a different ID from `bd ready --unassigned`. **Do not** create a branch or modify the repo for a Beads task until your claim succeeds. Skipping this step causes duplicate work when multiple agents run in parallel.
+
 ### Starting a Session
 
-1. See ready work (no open blockers): `bd ready`
-2. Optionally filter by assignee, label, type, or limit: `bd ready --unassigned -n 5`
-3. For JSON (scripts/agents): `bd ready --json`
+1. See ready unclaimed work: `bd ready --unassigned` (add `-n 5` to cap the list). For JSON: `bd ready --unassigned --json`
+2. Optionally also run `bd ready` to see your own in-progress items.
 
 ### Claiming a Task
 
@@ -74,7 +79,7 @@ Use 'bd' for task tracking. See .workflow/beads-coordination.md.
 bd update <id> --claim
 ```
 
-Fails if the issue is already claimed. Use `BD_ACTOR` or `--actor` to set the assignee name (defaults to `git user.name` or `$USER`).
+Fails if the issue is already claimed. Use `BD_ACTOR` or `--actor` to set the assignee name (defaults to `git user.name` or `$USER`). **Claim must succeed before any git branch or file changes for that task.**
 
 ### Creating a Task
 
@@ -150,7 +155,7 @@ bd show --current      # Last touched / in-progress issue
 
 ### Multi-Agent Claiming
 
-`bd update <id> --claim` is atomic. If two agents claim the same issue, one will fail. Before claiming, re-run `bd ready` and pick an issue that is still unassigned.
+`bd update <id> --claim` is atomic. If two agents claim the same issue, one will fail—that agent must pick another task, not start coding anyway. **Never** proceed with implementation on a task whose claim failed. Re-run `bd ready --unassigned` after a failed claim.
 
 ### Staleness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Set these for your agent (example values shown for Claude Code):
 3. Read `.workflow/issue-tracker.md` to see which issue tracker this project uses, then follow the coordination guide linked there to find and claim work (and to avoid file conflicts with the other model’s in-progress work)
 4. If no work is available, ask your operator what to work on
 
+**Beads — claim first:** Run `bd update <id> --claim` and succeed *before* creating a branch or editing files for that task. If claim fails, pick another task.
+
 Work on a feature branch only; never push to main.
 
 ## Workflow Reference


### PR DESCRIPTION
- START HERE: rule 6 + session order (claim → branch)
- beads-coordination: claim-before-work section; multi-agent failure handling
- How We Work, Tips & Lessons, .cursorrules, CLAUDE.md aligned

Made-with: Cursor