### PR TITLE
feat: add CSRF protection via Flask-WTF (T29)

### DIFF
--- a/.metrics/metrics-claude.md
+++ b/.metrics/metrics-claude.md
@@ -11,6 +11,7 @@
 |---------|------|--------------------|-----|-----------|------------|-------|--------|----------|---------------|------|------------|
 | 8 | Mar 10 | -- | 3 | 1 | Fixed 4 bugs (#21, #22, #26, #36), Meta Tracker sync, session close-out workflow (#55) | Build | collaborative | michael | Bug | Claude Code | #21, #22, #26, #36 |
 | 9 | Mar 10 | ~30 min | 2 | 1 | Bare exception fix (#37), stale refs (#15), Docker modernization (#23, #25, #39), closed #52 #16 | Build | ai | michael | Bug, Tooling | Claude Code | #37 |
+| 10 | Mar 26 | ~45 min | 1 | 0 | CSRF protection via Flask-WTF (T29 / vuln-bank-1zj.3) | Build | ai | hpatel | Security | Claude Code | -- |
 
 ## Code Volume
 
@@ -18,6 +19,7 @@
 |---------|------|-------------|---------------|------------|-------------------|
 | 8 | Mar 10 | 159 | 41 | +118 | README.md, app.py, auth.py, Dockerfile, openapi.json, index.html, metrics-claude.md, metrics-cursor.md, START HERE.md, How We Work.md, metrics.md |
 | 9 | Mar 10 | 24 | 18 | +6 | app.py, How We Work.md, Dockerfile, docker-compose.yml, README.md |
+| 10 | Mar 26 | ~60 | ~10 | +50 | requirements.txt, app.py, static/dashboard.js, templates/login.html, register.html, forgot_password.html, reset_password.html, dashboard.html, admin.html |
 
 ## PR Activity
 
@@ -26,6 +28,7 @@
 | 8 | Mar 10 | 1 | -- | 2 | PR #53: Fix 4 bugs (Commando-X refs, debug prints, dead SQLite, upload perms) |
 | 8 | Mar 10 | 1 | 1 | 1 | PR #56: Session close-out workflow + split metrics files (#55) |
 | 9 | Mar 10 | 2 | 2 | 2 | PR #102: Bare exceptions + stale refs (#37, #15). PR #104: Docker modernization (#23, #25, #39) |
+| 10 | Mar 26 | 1 | -- | 1 | PR: CSRF protection (T29 / vuln-bank-1zj.3) |
 
 ## Bugs Found/Fixed
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify, make_response
+from flask_wtf.csrf import CSRFProtect
 from datetime import datetime, timedelta
 import random
 import secrets
@@ -58,6 +59,9 @@ def set_anti_clickjacking_headers(response):
 
 # T76: Use env for secret key; no hardcoded default in production
 app.secret_key = os.getenv('FLASK_SECRET_KEY') or os.getenv('SECRET_KEY') or 'secret123'
+
+# T29: CSRF protection via Flask-WTF
+csrf = CSRFProtect(app)
 
 # Rate limiting configuration
 RATE_LIMIT_WINDOW = 3 * 60 * 60  # 3 hours in seconds

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ werkzeug==2.0.1
 pyjwt==2.4.0
 flask-swagger-ui==4.11.1
 flask-cors==4.0.0
+flask-wtf==1.2.2
 psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 requests==2.31.0

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1,3 +1,9 @@
+// T29: Return CSRF token from the meta tag injected by Flask-WTF
+function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.content : '';
+}
+
 // Set current date
 document.addEventListener('DOMContentLoaded', function() {
     const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
@@ -101,7 +107,8 @@ async function handleTransfer(event) {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify(jsonData)
         });
@@ -140,7 +147,8 @@ async function handleLoanRequest(event) {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify(jsonData)
         });
@@ -203,7 +211,8 @@ async function handleProfileUpload(event) {
         const response = await fetch('/upload_profile_picture', {
             method: 'POST',
             headers: {
-                'Authorization': 'Bearer ' + localStorage.getItem('jwt_token')
+                'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
+                'X-CSRFToken': getCsrfToken()
             },
             body: formData
         });
@@ -236,7 +245,8 @@ async function handleProfileUrlImport() {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify({ image_url: imageUrl })
         });
@@ -430,7 +440,8 @@ async function handleCreateCard(event) {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify(jsonData)
         });
@@ -457,7 +468,8 @@ async function toggleCardFreeze(cardId) {
         const response = await fetch(`/api/virtual-cards/${cardId}/toggle-freeze`, {
             method: 'POST',
             headers: {
-                'Authorization': 'Bearer ' + localStorage.getItem('jwt_token')
+                'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
+                'X-CSRFToken': getCsrfToken()
             }
         });
 
@@ -560,7 +572,8 @@ async function handleCardUpdate(event, cardId) {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify(jsonData)
         });
@@ -728,7 +741,8 @@ async function handleBillPayment(event) {
             method: 'POST',
             headers: {
                 'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             },
             body: JSON.stringify(jsonData)
         });
@@ -969,12 +983,14 @@ async function sendToAI(message) {
             endpoint = '/api/ai/chat';
             headers = {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${token}`
+                'Authorization': `Bearer ${token}`,
+                'X-CSRFToken': getCsrfToken()
             };
         } else {
             endpoint = '/api/ai/chat/anonymous';
             headers = {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
             };
         }
         

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='admin.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div class="container">
@@ -182,7 +183,8 @@
                     method: 'POST',
                     headers: {
                         'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                     }
                 });
 
@@ -214,7 +216,8 @@
                     method: 'POST',
                     headers: {
                         'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                     }
                 });
 
@@ -249,7 +252,8 @@
                     method: 'POST',
                     headers: {
                         'Authorization': 'Bearer ' + localStorage.getItem('jwt_token'),
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                     },
                     body: JSON.stringify(jsonData)
                 });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='dashboard.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <!-- Mobile menu toggle -->

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='auth.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div class="container">
@@ -44,7 +45,8 @@
                     const response = await fetch('/api/v3/forgot-password', {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json'
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                         },
                         body: JSON.stringify(jsonData)
                     });

--- a/templates/login.html
+++ b/templates/login.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='auth.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div class="container">
@@ -41,7 +42,8 @@
                     const response = await fetch('/login', {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json'
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                         },
                         body: JSON.stringify(jsonData)
                     });

--- a/templates/register.html
+++ b/templates/register.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='auth.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div class="container">
@@ -41,7 +42,8 @@
                     const response = await fetch('/register', {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json'
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                         },
                         body: JSON.stringify(jsonData)
                     });

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='auth.css') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 </head>
 <body>
     <div class="container">
@@ -48,7 +49,8 @@
                     const response = await fetch('/api/v3/reset-password', {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json'
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
                         },
                         body: JSON.stringify(jsonData)
                     });


### PR DESCRIPTION
Closes vuln-bank-1zj.3 — Use anti-CSRF tokens

## What
- Added flask-wtf==1.2.2 as a dependency
- Initialized CSRFProtect in app.py (uses Flask's secret_key, already configured)
- All six templates now inject a `<meta name="csrf-token">` tag via `{{ csrf_token() }}`
- All state-changing POST fetch() calls send the `X-CSRFToken` header, covering:
  - Login, register, forgot/reset password
  - Dashboard: money transfer, loan request, profile upload, virtual cards, bill payments, AI chat
  - Admin: delete account, approve loan, create admin

## How it works
Flask-WTF generates a per-session CSRF secret (stored in the Flask session cookie) and exposes it as a signed token via `csrf_token()` in templates. On each POST, the `X-CSRFToken` header is validated server-side against the session secret. Requests without a valid token are rejected with 400.